### PR TITLE
Bij openen 'Andere sites' menu, focus eerste focusbare element

### DIFF
--- a/src/components/page-components/header/handlers/toggleOtherSites.js
+++ b/src/components/page-components/header/handlers/toggleOtherSites.js
@@ -11,6 +11,14 @@ module.exports = function toggleOtherSites( element ) {
 
   else {
     ui.show( otherSites );
+
+    if ( ui.getFocusableElements( otherSites ).length > 0 ) {
+      ui.focus( ui.getFocusableElements( otherSites )[0] );
+    }
+    else {
+      ui.focus ( otherSites );
+    }
+
     element.setAttribute( 'aria-expanded', 'true' );
   }
 };


### PR DESCRIPTION
Als het menu geen focusbaar element bevat, focus dan het menu zelf (dan krijgt het ook een focus-indicatie, dus blauwe rand, om zich heen)