### PR TITLE
Fix header op mobiel; fix animatie

### DIFF
--- a/src/components/page-components/header/_header.scss
+++ b/src/components/page-components/header/_header.scss
@@ -55,12 +55,7 @@
 
   &__nav {
     background-color: $headerBackgroundColor;
-    animation: openNav 0.8s ease-in-out;
     position: relative;
-
-    @media ( min-width: 50em ) {
-      animation: none;
-    }
 
     > .container {
       display: flex;
@@ -175,10 +170,10 @@
       padding-bottom: 1em;
       display: flex;
       flex-direction: column;
-      animation: openNav 0.8s cubic-bezier(0, 0.47, 0.58, 1);
 
       @media ( min-width: 50em ) {
         flex-direction: row;
+        animation: openNav 0.8s cubic-bezier(0, 0.47, 0.58, 1);
       }
 
       div {

--- a/src/components/page-components/header/_header.scss
+++ b/src/components/page-components/header/_header.scss
@@ -191,39 +191,22 @@
 @keyframes openNav {
 
     0% {
-      transform: translateY( -100% );
-      margin-top: -100%;
+      max-height: 0;
     }
 
-    1% {
-      z-index: -1;
-    }
 
     100% {
-      transform: translateY( 0 );
-      z-index: 1;
-      margin-top: 0;
+      max-height: 30em;
     }
 }
 
 @keyframes closeNav {
 
     0% {
-      transform: translateY( 0 );
-      z-index: 1;
-      opacity: 1;
-      margin-top: 0;
-      position: static;
-    }
-
-    99% {
-      z-index: -1;
+      max-height: 30em;
     }
 
     100% {
-      opacity: 0;
-      transform: translateY(-100%);
-      position: absolute;
-      margin-top: -100%;
+      max-height: 0;
     }
 }

--- a/src/components/page-components/header/handlers/toggleOtherSites.js
+++ b/src/components/page-components/header/handlers/toggleOtherSites.js
@@ -1,8 +1,10 @@
-module.exports = function toggleOtherSites( element ) {
+module.exports = function toggleOtherSites( element, event ) {
   var dom = require( 'helpers/dom' );
   var ui = require( 'helpers/ui' );
   var otherSites = dom.getElementFromHref( element.href );
   var toggleState = element.getAttribute( 'aria-expanded' );
+
+  event.preventDefault();
 
   if ( toggleState === 'true' ) {
     ui.hide( otherSites );

--- a/src/components/page-components/header/header.handlebars
+++ b/src/components/page-components/header/header.handlebars
@@ -21,6 +21,7 @@
         <li><a href="#">Overheidsinformatie</a></li>
       </ul>
       {{ render "@search" search merge="true" }}
+      <a href="#other-sites" class="hidden-desktop" data-handler="toggle-other-sites" data-decorator="init-toggle-other-sites"><span class="visually-hidden">Andere sites binnen </span>Overheid.nl</a>
     </div>
   </nav>
 </header>

--- a/src/components/page-components/search/_search.scss
+++ b/src/components/page-components/search/_search.scss
@@ -2,31 +2,45 @@
   overflow: hidden;
   position: relative;
   width: 17em;
+  margin: 0.5em 1em 1em;
+
+  @media ( min-width: 50em ) {
+    margin: 0;
+  }
 
   .search__term {
     -webkit-appearance: none;
-    position: absolute;
-    right: 40px;
-    top: .5em;
-    width: 15em;
-    height: 40px;
-    left: -999em;
-
     border: none;
     font-family: inherit;
     padding: 0 .5em;
     font-size: .85em;
+    height: 40px;
+    width: 100%;
     outline: 2px solid transparent;
     outline-offset: .5em;
     transition: color $fastEaseInOut, outline-offset $fastEaseInOut;
 
+    @media ( min-width: 50em ) {
+      position: absolute;
+      right: 40px;
+      top: .5em;
+      width: 15em;
+      left: -999em;
+    }
+
     &--hidden {
-      width: 0;
-      border: 0;
-      padding: 0;
+
+      @media ( min-width: 50em ) {
+        width: 0;
+        border: 0;
+        padding: 0;
+      }
 
       + button {
-        background-color: $headerBackgroundColor;
+
+        @media ( min-width: 50em ) {
+          background-color: $headerBackgroundColor;
+        }
       }
     }
 
@@ -47,21 +61,13 @@
     height: 40px;
     position: absolute;
     right: 0;
-    top: .6em;
+    top: 0;
     text-indent: -999em;
     outline: 2px solid transparent;
     outline-offset: .5em;
     transition: color $fastEaseInOut, outline-offset $fastEaseInOut;
-
     border: none;
     appearance: none;
-
-    &:focus {
-      outline: 2px solid $yellow;
-      outline-offset: -2px;
-
-    }
-
     background: {
       color: $black;
       image: $searchIcon;
@@ -70,9 +76,15 @@
       size: 30px;
     }
     cursor: pointer;
+
+    @media ( min-width: 50em ) {
+      top: .6em;
+    }
+
+    &:focus {
+      outline: 2px solid $yellow;
+      outline-offset: -2px;
+    }
   }
-
-
-
 }
 


### PR DESCRIPTION
Aanpassingen: 

* toegevoegd op mobiel: search en 'overheid.nl' uitklapper. Het wordt wat druk, design tweaks wenselijk in de toekomst
* op mobiel animaties verwijderd; werkte niet lekker op echte telefoon, want je hele content schuift naar beneden en dat gaat op bijna geen enkel device smooth, en ziet er gek uit
* bij uitklappen ‘overheid.nl’ doen we nu `preventDefault()`, zodat je niet naar het uitklappende stukje springt
* op desktop animatie ‘overheid.nl’ smoother gemaakt (en met wat minder ingewikkelde CSS)