### PR TITLE
Voeg alleen `add-foldability` decorator toe als dat nodig is

### DIFF
--- a/src/components/common/treeview/treeview.config.yml
+++ b/src/components/common/treeview/treeview.config.yml
@@ -1,10 +1,12 @@
 title: Treeview
-status: wip
+status: ready
 context:
   label: default
+  foldability: false
 variants:
 - name: foldable
   label: foldable
   status: ready
   context:
     modifier: treeview--foldable
+    foldability: true

--- a/src/components/common/treeview/treeview.handlebars
+++ b/src/components/common/treeview/treeview.handlebars
@@ -1,30 +1,30 @@
 <ul class="treeview {{ modifier }}" id="treeview-{{ id }}">
   <li>
-    <a href="#" class="foldable" data-decorator="add-foldability">
+    <a href="#" class="foldable"{{#if foldability }} data-decorator="add-foldability"{{/if}}>
       Hoofdstuk 1
       <small>Ministerie van Binnenlandse Zaken en Koninkrijksrelaties</small>
     </a>
 
     <ul id="unique-id-1">
-      <li><a href="#" data-decorator="add-foldability">Artikel 1</a>
+      <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1</a>
         <ul id="unique-id-2">
-          <li><a href="#" data-decorator="add-foldability">Artikel 1.1</a></li>
-          <li><a href="#" data-decorator="add-foldability">Artikel 1.2</a>
+          <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.1</a></li>
+          <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.2</a>
             <ul id="unique-id-3">
-              <li><a href="#" data-decorator="add-foldability">Artikel 1.1</a></li>
-              <li><a href="#" data-decorator="add-foldability">Artikel 1.2</a>
+              <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.1</a></li>
+              <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.2</a>
                 <ul>
-                  <li><a href="#" data-decorator="add-foldability">Artikel 1.1</a></li>
-                  <li><a href="#" data-decorator="add-foldability">Artikel 1.2</a></li>
+                  <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.1</a></li>
+                  <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.2</a></li>
                 </ul>
               </li>
             </ul>
             <ul id="unique-id-4">
-              <li><a href="#" data-decorator="add-foldability">Artikel 1.1</a></li>
-              <li><a href="#" data-decorator="add-foldability">Artikel 1.2</a>
+              <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.1</a></li>
+              <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.2</a>
                 <ul>
-                  <li><a href="#" data-decorator="add-foldability">Artikel 1.1</a></li>
-                  <li><a href="#" data-decorator="add-foldability">Artikel 1.2</a></li>
+                  <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.1</a></li>
+                  <li><a href="#"{{#if foldability }} data-decorator="add-foldability"{{/if}}>Artikel 1.2</a></li>
                 </ul>
               </li>
             </ul>


### PR DESCRIPTION
Bug: de `data-decorator="add-foldability` werden ook toegevoegd in de treeview die niet foldable was, dat zag er niet uit.

Treeview is nu niet foldable in de ‘default’ variant, en wel in de ‘foldable’ variant. Beide staan nu op `ready`.