### PR TITLE
Making the wetgevingskalender search page looks less chaotic

### DIFF
--- a/src/@koop-components/page-components/sticky-sidebar/sticky-sidebar.handlebars
+++ b/src/@koop-components/page-components/sticky-sidebar/sticky-sidebar.handlebars
@@ -6,33 +6,30 @@
 </div>
 <div class="container columns columns--sticky-sidebar row">
   <div class="columns--sticky-sidebar__sidebar" data-decorator="stick-sidebar add-mobile-foldability" id="toggleable-1">
-      <div>
+    <div>
 
-        <a href="#" class="icon--backlink">Terug naar zoekresultaten (9430)</a>
+      <a href="#" class="icon--backlink">Terug naar zoekresultaten (9430)</a>
+      <a href="#">&laquo; Vorige</a> <a href="#" class="pull-right">Volgende &raquo;</a>
 
-        <a href="#">&laquo; Vorige</a> <a href="#" class="pull-right">Volgende &raquo;</a>
-
-        <h2>Goedkeuringswet Verdrag tussen Nederland en Noorwegen (...) <span>Geldend van 01-07-2016 t/m heden</span></h2>
-        <div class="actionblock">
-            <ul class="actionblock__list">
-                <li>
-                    <a href="#">
-              <img src="../../images/icon-plus.svg" alt="" role="presentation" />
-              Alles openklappen
-              </a>
-                </li>
-                <li>
-                    <a href="#">
-              <img src="../../images/icon-minus.svg" alt="" role="presentation" />
-              Alles dichtklappen
-              </a>
-                </li>
-            </ul>
-        </div>
-
-        <h2>Inhoudsopgave</h2>
-        {{ render "@treeview" }}
+      <h2>Goedkeuringswet Verdrag tussen Nederland en Noorwegen (...) <span>Geldend van 01-07-2016 t/m heden</span></h2>
+      <div class="actionblock">
+        <ul class="actionblock__list">
+          <li>
+            <a href="#">
+              <img src="../../images/icon-plus.svg" alt="" role="presentation" /> Alles openklappen
+            </a>
+          </li>
+          <li>
+            <a href="#">
+              <img src="../../images/icon-minus.svg" alt="" role="presentation" /> Alles dichtklappen
+            </a>
+          </li>
+        </ul>
       </div>
+
+      <h2>Inhoudsopgave</h2>
+      {{ render "@treeview" }}
+    </div>
   </div>
   <div>
     <h1>Goedkeuringswet Verdrag tussen Nederland en Noorwegen inzake het gebruik van een [...] vonnissen opgelegde vrijheidsstraffen (Trb. 2015, 37)</h1>

--- a/src/@koop-components/templates/wetgevingkalendernl-templates/wk-search-extended.handlebars
+++ b/src/@koop-components/templates/wetgevingkalendernl-templates/wk-search-extended.handlebars
@@ -85,23 +85,6 @@
           <div class="form__element">
             <div class="form__element__label">
               <label for="ZoekOp_Overheidsdomein">Type</label>
-              <div class="question-explanation">
-                <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2"
-                  id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00" class="question-explanation__link"
-                  data-handler="toggle-explanation">
-                  Toelichting zoeken op {variable}
-                </a>
-
-                <div id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2" class="question-explanation__content"
-                  data-decorator="hide-self" hidden="true">
-
-
-                  <p>{text}</p>
-
-                  <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00"
-                    class="question-explanation__close" data-handler="close-explanation">Sluiten</a>
-                </div>
-              </div>
             </div>
             <div class="form__element__inputs">
               <select>
@@ -115,23 +98,6 @@
           <div class="form__element">
             <div class="form__element__label">
               <label for="ZoekOp_Overheidsdomein">Beleidsonderwerp</label>
-              <div class="question-explanation">
-                <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2"
-                  id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00" class="question-explanation__link"
-                  data-handler="toggle-explanation">
-                  Toelichting zoeken op {variable}
-                </a>
-
-                <div id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2" class="question-explanation__content"
-                  data-decorator="hide-self" hidden="true">
-
-
-                  <p>{text}</p>
-
-                  <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00"
-                    class="question-explanation__close" data-handler="close-explanation">Sluiten</a>
-                </div>
-              </div>
             </div>
             <div class="form__element__inputs">
               <select>
@@ -145,23 +111,6 @@
           <div class="form__element">
             <div class="form__element__label">
               <label for="ZoekOp_Overheidsdomein">Implementatie</label>
-              <div class="question-explanation">
-                <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2"
-                  id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00" class="question-explanation__link"
-                  data-handler="toggle-explanation">
-                  Toelichting zoeken op {variable}
-                </a>
-
-                <div id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2" class="question-explanation__content"
-                  data-decorator="hide-self" hidden="true">
-
-
-                  <p>{text}</p>
-
-                  <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00"
-                    class="question-explanation__close" data-handler="close-explanation">Sluiten</a>
-                </div>
-              </div>
             </div>
             <div class="form__element__inputs">
               <select>
@@ -206,24 +155,7 @@
 
           <div class="form__element">
             <div class="form__element__label">
-              <label for="ZoekOp_Overheidsdomein">Ministerie</label>
-              <div class="question-explanation">
-                <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2"
-                  id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00" class="question-explanation__link"
-                  data-handler="toggle-explanation">
-                  Toelichting zoeken op {variable}
-                </a>
-
-                <div id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2" class="question-explanation__content"
-                  data-decorator="hide-self" hidden="true">
-
-
-                  <p>{text}</p>
-
-                  <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00"
-                    class="question-explanation__close" data-handler="close-explanation">Sluiten</a>
-                </div>
-              </div>
+              <label for="ZoekOp_Overheidsdomein">Status</label>
             </div>
             <div class="form__element__inputs">
               <ul class="list--unstyled">
@@ -252,23 +184,6 @@
           <div class="form__element">
             <div class="form__element__label">
               <label for="ZoekOp_Overheidsdomein">Fase</label>
-              <div class="question-explanation">
-                <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2"
-                  id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00" class="question-explanation__link"
-                  data-handler="toggle-explanation">
-                  Toelichting zoeken op {variable}
-                </a>
-
-                <div id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2" class="question-explanation__content"
-                  data-decorator="hide-self" hidden="true">
-
-
-                  <p>{text}</p>
-
-                  <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00"
-                    class="question-explanation__close" data-handler="close-explanation">Sluiten</a>
-                </div>
-              </div>
             </div>
             <div class="form__element__inputs">
               <select>
@@ -285,23 +200,6 @@
           <div class="form__element">
             <div class="form__element__label">
               <label for="ZoekOp_Overheidsdomein">Eerste ondertekenaar</label>
-              <div class="question-explanation">
-                <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2"
-                  id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00" class="question-explanation__link"
-                  data-handler="toggle-explanation">
-                  Toelichting zoeken op {variable}
-                </a>
-
-                <div id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2" class="question-explanation__content"
-                  data-decorator="hide-self" hidden="true">
-
-
-                  <p>{text}</p>
-
-                  <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00"
-                    class="question-explanation__close" data-handler="close-explanation">Sluiten</a>
-                </div>
-              </div>
             </div>
             <div class="form__element__inputs">
               <select>
@@ -314,23 +212,6 @@
           <div class="form__element">
             <div class="form__element__label">
               <label for="ZoekOp_Overheidsdomein">Medeondertekenaar</label>
-              <div class="question-explanation">
-                <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2"
-                  id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00" class="question-explanation__link"
-                  data-handler="toggle-explanation">
-                  Toelichting zoeken op {variable}
-                </a>
-
-                <div id="ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_Inhoud2" class="question-explanation__content"
-                  data-decorator="hide-self" hidden="true">
-
-
-                  <p>{text}</p>
-
-                  <a href="../../Controls/Algemeen/#ctl00_ctl00_cphContent_zoekpaginaContent_ZoekformulierUitgebreid_InfoZoekOp_Overheidsdomein_ctl00"
-                    class="question-explanation__close" data-handler="close-explanation">Sluiten</a>
-                </div>
-              </div>
             </div>
             <div class="form__element__inputs">
               <select>

--- a/src/@koop-components/templates/wetgevingkalendernl-templates/wk-search-extended.handlebars
+++ b/src/@koop-components/templates/wetgevingkalendernl-templates/wk-search-extended.handlebars
@@ -157,7 +157,7 @@
             <div class="form__element__label">
               <label for="ZoekOp_Overheidsdomein">Status</label>
             </div>
-            <div class="form__element__inputs">
+            <div class="form__element__inputs radiogroup">
               <ul class="list--unstyled">
                 <li>
                   <label for="ZoekOp_DatumtypeInwerkingtreding">


### PR DESCRIPTION
- Removed question mark icons wherever possible, keeping the ones that were originally used.
- Most feedback was already implemented and merged before, this is only regarding the last question, which was: "Opdrachtgever vond dit erg onrustig, is daar iets aan te doen om het rustiger te laten ogen?"