### PR TITLE
Fix for the layout issue on the ROI homepage

### DIFF
--- a/src/@koop-components/templates/roi/home.handlebars
+++ b/src/@koop-components/templates/roi/home.handlebars
@@ -7,37 +7,26 @@
 </div>
 
 <div class="row container">
-
-    <h1>Zoeken</h1>
-
-    {{ render "@roi-search" }}
-
-</div>
-
-<div class="row container columns">
-  <div>
-
-    <h2>kenmerken</h2>
-
-    {{ render "@collapsible" filter1 merge=true }}
-    {{ render "@collapsible" filter2 merge=true }}
-    {{ render "@collapsible" filter3 merge=true }}
-    {{ render "@collapsible" filter4 merge=true }}
-
+  <h1>Zoeken</h1>
+  {{ render "@roi-search" }}
+  
+  <div class="row container columns">
+    <div>
+      <h2>kenmerken</h2>
+      {{ render "@collapsible" filter1 merge=true }}
+      {{ render "@collapsible" filter2 merge=true }}
+      {{ render "@collapsible" filter3 merge=true }}
+      {{ render "@collapsible" filter4 merge=true }}
+    </div>
+    <div>
+      <h2>Datum</h2>
+      {{ render "@input-radio" }}
+      
+      <h2>Nummers</h2>
+      {{ render "@input-text" filter5 merge=true }}
+      <input type="submit" value="Zoeken" class="button button--secondary pull-right" />
+    </div>
   </div>
-
-  <div>
-    <h2>Datum</h2>
-
-    {{ render "@input-radio" }}
-
-    <h2>Nummers</h2>
-
-    {{ render "@input-text" filter5 merge=true }}
-
-    <input type="submit" value="Zoeken" class="button button--secondary pull-right" />
-  </div>
-
 </div>
 
 {{ render "@footer" }}


### PR DESCRIPTION
- The layout was not rendering correctly on larger screen sizes. The part after the ROI search component was displayed on the far right of the screen rather than under the ROI search, which it did accordingly on smaller screen sizes.