### PR TITLE
Improvement/make components more versatile

### DIFF
--- a/src/@koop-components/common/list/list.handlebars
+++ b/src/@koop-components/common/list/list.handlebars
@@ -26,11 +26,19 @@
   {{#each items }}
     {{#if subitems }}
     <li>{{{ text }}}
-      <ol>
-      {{#each subitems }}
-        <li>{{{ text }}}</li>
-      {{/each }}
-      </ol>
+      {{#if orderedList }}
+        <ol>
+        {{#each subitems }}
+          <li>{{{ text }}}</li>
+        {{/each }}
+        </ol>
+      {{else}}
+        <ul>
+          {{#each subitems }}
+            <li>{{{text}}}</li>
+          {{/each }}
+        </ul>
+      {{/if }}
     </li>
     {{else}}
       <li>{{{ text }}}</li>

--- a/src/@koop-components/form-components/select/select.config.yml
+++ b/src/@koop-components/form-components/select/select.config.yml
@@ -5,3 +5,13 @@ context:
   id: 1
   fieldLabel: Aantal resultaten per pagina
   fieldInstruction: verplicht veld
+  values:
+    - value:
+      inputValue: 10
+      displayValue: 10
+    - value:
+      inputValue: 20
+      displayValue: 20
+    - value:
+      inputValue: 50
+      displayValue: 50

--- a/src/@koop-components/form-components/select/select.handlebars
+++ b/src/@koop-components/form-components/select/select.handlebars
@@ -4,8 +4,8 @@
     <small>{{ fieldInstruction }}</small>
   {{/if }}
   <select id="select--{{ id }}">
-    <option value="10">10</option>
-    <option value="25">25</option>
-    <option value="100">100</option>
+    {{#each values}}
+    <option value="{{inputValue}}">{{displayValue}}</option>
+    {{/each}}
   </select>
 </div>


### PR DESCRIPTION
**Wait till after release to merge these changes**

These changes are all results of building the Wettenpocket templates.
Ran into some restrictions of the existing components and made them a little more versatile.
- Added the option to nest unordered lists
- Made the input select component reusable/configurable