### PR TITLE
Changed default table-layout to fixed

### DIFF
--- a/src/@koop-components/common/table/_table.scss
+++ b/src/@koop-components/common/table/_table.scss
@@ -14,6 +14,7 @@ table,
   width: 100%;
   border-collapse: collapse;
   margin: 1em 0;
+  table-layout: fixed;
 
   caption {
     color: $darkerGrey;


### PR DESCRIPTION
This will, in general improve the way tables are displayed since the columns will be distributed more equal than the default `auto` where columns are made wide enough to fit the content. Especially when multiple tables are placed on one page this causes them to look messy.
See attached screenshots as an example.
Without the fix
![screenshot 2018-12-06 10 51 33](https://user-images.githubusercontent.com/754066/49576397-60639a00-f945-11e8-9cea-9b1c2f0dc0c8.png)

With the fix.
![screenshot 2018-12-06 10 52 00](https://user-images.githubusercontent.com/754066/49576451-825d1c80-f945-11e8-8e80-f993c454b7de.png)

