### PR TITLE
Added an exception for the tables

### DIFF
--- a/src/@koop-components/common/table/_table.scss
+++ b/src/@koop-components/common/table/_table.scss
@@ -16,6 +16,10 @@ table,
   margin: 1em 0;
   table-layout: fixed;
 
+  .table--container & {
+    table-layout: auto;
+  }
+
   caption {
     color: $darkerGrey;
     text-align: left;


### PR DESCRIPTION
Tables that are contained within a `table--container` get auto layout instead of fixed. This way they maintain horizontal scroll.