### PR TITLE
⚗️  Added a variant of tooltip

### DIFF
--- a/src/@koop-components/form-components/tooltip/_tooltip.scss
+++ b/src/@koop-components/form-components/tooltip/_tooltip.scss
@@ -9,9 +9,13 @@
     display: inline;
   }
 
-  span[aria-hidden="true"] {display:none;}
-  span[aria-hidden="false"] {display:block;}
+  span[aria-hidden="true"] {
+    display:none;
+  }
 
+  span[aria-hidden="false"] {
+    display:block;
+  }
 }
 
 .has-js .tooltip {
@@ -37,6 +41,7 @@
       background-image: $explanationHoverIcon;
     }
   }
+
   &__content {
     border: 1px solid $tooltipContainerBorderColor;
     font-size: inherit;
@@ -53,7 +58,6 @@
     border-radius: 5px;
     line-height: 1em;
 
-
     @media ( min-width: 400px ) {
       position: absolute;
       top: 1.5em;
@@ -61,8 +65,6 @@
       max-width: 20em;
       min-width: 18em;
     }
-
-
 
     &.has-position--fixed {
       left: 1em;
@@ -104,6 +106,19 @@
         right: .75em;
         left: auto !important;
       }
+    }
+  }
+}
+
+.tooltip--info {
+
+  .tooltip__trigger {
+    background-image: $infoIcon;
+    background-size: 18px;
+
+    &:hover,
+    &:focus {
+      background-image: $infoIcon;
     }
   }
 }

--- a/src/@koop-components/form-components/tooltip/tooltip.config.yml
+++ b/src/@koop-components/form-components/tooltip/tooltip.config.yml
@@ -4,6 +4,12 @@ label: Tooltip
 status: wip
 context:
   id: 1
-  label: label
+  label: Help?
   Helptext: U moet dit volledig en naar waarheid invullen
-
+variants:
+  - name: Tooltip Info
+    context:
+      id: 2
+      modifier: tooltip--info
+      label: Extra Info
+      Helptext: Dit is een notitie van de uitgever.

--- a/src/@koop-components/form-components/tooltip/tooltip.handlebars
+++ b/src/@koop-components/form-components/tooltip/tooltip.handlebars
@@ -1,4 +1,4 @@
-<div class="tooltip" data-decorator="tooltip">
-  <button  aria-label="Help?" aria-describedby="tt{{id}}" aria-expanded="false" class="tooltip__trigger">{{label}}</button>
+<div class="tooltip {{modifier}}" data-decorator="tooltip">
+  <button aria-label="{{label}}" aria-describedby="tt{{id}}" aria-expanded="false" class="tooltip__trigger">{{label}}</button>
   <span role="tooltip" id="tt{{id}}" class="tooltip__content">{{Helptext}}</span>
 </div>


### PR DESCRIPTION
Just putting this, not really sure if this is worth a variant or not. We already have a tooltip, but it always displays a "?" icon, though in some context another icon might be preferrable. For instance in my case, in the Wettenpocket a user can make an annotation on a law article. In that case an "i" for extra information might give a better understanding of the intention of the publisher.
Might be overkill. If you think so, feel free to delete the branch :)

Also, cleaned up source code a bit.