### PR TITLE
🐛 Replace overflow hidden with list style none

### DIFF
--- a/src/@koop-components/common/list/_list.scss
+++ b/src/@koop-components/common/list/_list.scss
@@ -5,7 +5,7 @@ ul {
 td ul {
   padding: 0;
   margin: 0;
-  overflow: hidden;
+  list-style: none;
 
   li {
     margin: 0;


### PR DESCRIPTION
Lists in tables had default overflow: hidden which caused some unforseen bugs.
It was there to prevent list images, like bullets, showing. So replace the property with the more fitting list-style: none.

Visual regression test showed no unexpected results.