### PR TITLE
🐛 Make the language attribute configurable

### DIFF
--- a/src/@koop-components/common/blockquote/blockquote.config.yml
+++ b/src/@koop-components/common/blockquote/blockquote.config.yml
@@ -2,5 +2,6 @@
 title: Blockquote
 label: Blockquote
 context:
+  lang: en
   text: Yes, we can.
   cite: Barack Obama

--- a/src/@koop-components/common/blockquote/blockquote.handlebars
+++ b/src/@koop-components/common/blockquote/blockquote.handlebars
@@ -1,5 +1,4 @@
-<blockquote {{#if modifier}}class="blockquote blockquote--{{modifier}}"{{/if}}>
-  <p lang="en">{{text}}</p>
-
+<blockquote>
+  <p {{#if lang}}lang="{{ lang }}"{{/if}}>{{text}}</p>
   {{#if cite}}<cite>{{cite}}</cite>{{/if}}
 </blockquote>


### PR DESCRIPTION
The language attribute was hardcoded in the template. Made that configurable. Also removed the modifier because no CSS has been specified for it.