### PR TITLE
🛁 Added the correct color names to the swatches

### DIFF
--- a/src/@koop-components/common/colors/colors.handlebars
+++ b/src/@koop-components/common/colors/colors.handlebars
@@ -16,12 +16,12 @@
 
 <h2>Actiekleuren</h2>
 <div class="color-sample green">green (#39870c)</div>
-<div class="color-sample darkgreen">green (#015f58)</div>
-<div class="color-sample lightgreen">green (#e4f0ef)</div>
+<div class="color-sample darkgreen">darkgreen (#015f58)</div>
+<div class="color-sample lightgreen">lightgreen (#e4f0ef)</div>
 <div class="color-sample yellow">yellow (#ffb612)</div>
-<div class="color-sample darkyellow">yellow (#f9d358)</div>
-<div class="color-sample lightyellow">yellow (#fff8e1)</div>
+<div class="color-sample darkyellow">darkyellow (#f9d358)</div>
+<div class="color-sample lightyellow">lightyellow (#fff8e1)</div>
 <div class="color-sample orange">orange (#e17000)</div>
-<div class="color-sample lightorange">orange (#f5e4e0)</div>
+<div class="color-sample lightorange">lightorange (#f5e4e0)</div>
 <div class="color-sample red">red<br /> (#d52b1e)</div>
-<div class="color-sample lightred">red<br /> (#f4c8c5)</div>
+<div class="color-sample lightred">lightred<br /> (#f4c8c5)</div>


### PR DESCRIPTION
To prevent confusion gave all the swatches the correct names.
Before: 
<img width="1056" alt="screenshot 2018-12-18 14 31 08" src="https://user-images.githubusercontent.com/754066/50162111-cb19bb80-02dd-11e9-9a07-e92e4fd9bafa.png">

After:
<img width="1061" alt="screenshot 2018-12-18 14 31 37" src="https://user-images.githubusercontent.com/754066/50162125-d371f680-02dd-11e9-8370-6b096121bb6d.png">
