### PR TITLE
Removed unused variable standardPadding

### DIFF
--- a/src/@koop-components/common/button-icon/_button-icon.scss
+++ b/src/@koop-components/common/button-icon/_button-icon.scss
@@ -118,5 +118,5 @@
   border-radius: none;
   color: $black;
   background-size: 1em;
-  padding: $standardPadding * 1.5;
+  padding: .75em;
 }

--- a/src/@koop-components/common/collapsible/_collapsible.scss
+++ b/src/@koop-components/common/collapsible/_collapsible.scss
@@ -4,7 +4,7 @@
   .collapsible__header {
     a {
       display: inline-block;
-      padding: $standardPadding;
+      padding: .5em;
       text-decoration: none;
       padding-left: 1em;
       color: $black;
@@ -40,7 +40,7 @@
     .collapsible__header {
       a {
         padding: 0 0 0 1em;
-        
+
         font: {
           size: 100%;
         }

--- a/src/@koop-components/common/table/_table.scss
+++ b/src/@koop-components/common/table/_table.scss
@@ -245,7 +245,7 @@ table,
         left: -100%;
         top: 0;
         width: 100%;
-        padding: $standardPadding;
+        padding: .5em;
         height: 100%;
         font-weight: 700;
         content: attr(data-before);

--- a/src/@koop-components/common/table/_table.scss
+++ b/src/@koop-components/common/table/_table.scss
@@ -46,7 +46,7 @@ table,
   tr td,
   tr th {
     border-bottom: 1px solid $lighterGrey;
-    padding: $standardPadding;
+    padding: .5em;
     vertical-align: top;
   }
 

--- a/src/assets/scss/generic/settings/_sizes.scss
+++ b/src/assets/scss/generic/settings/_sizes.scss
@@ -1,3 +1,2 @@
 $borderRadius: 0.5em;
 $standardButtonPadding: .75em 1em !default;
-$standardPadding: .5em !default;

--- a/src/assets/scss/transition/_components.scss
+++ b/src/assets/scss/transition/_components.scss
@@ -8,3 +8,4 @@
 @import '../../assets/scss/transition/components/input-checkbox';
 @import '../../assets/scss/transition/components/modal';
 @import '../../assets/scss/transition/components/resultlist';
+@import '../../assets/scss/transition/components/collapsible';

--- a/src/assets/scss/transition/components/_collapsible.scss
+++ b/src/assets/scss/transition/components/_collapsible.scss
@@ -1,0 +1,9 @@
+.collapsible {
+
+  .collapsible__header {
+
+    a {
+      padding: 1em;
+    }
+  }
+}

--- a/src/assets/scss/transition/components/_table.scss
+++ b/src/assets/scss/transition/components/_table.scss
@@ -1,3 +1,24 @@
-table {
+table,
+.table {
   font-size: 1.125em;
+
+  tr td,
+  tr th {
+    padding: 1em;
+  }
+}
+
+@media ( max-width: 50em ) {
+  table:not(.table__data-overview):not(.table__regulation),
+  &.table--condensed,
+  &.table--striped,
+  &.table--hover {
+
+    td {
+
+      &::before {
+        padding: 1em;
+      }
+    }
+  }
 }

--- a/src/assets/scss/transition/settings/_sizes.scss
+++ b/src/assets/scss/transition/settings/_sizes.scss
@@ -1,2 +1,1 @@
-$standardPadding: 1em;
 $borderRadius: 6px;


### PR DESCRIPTION
The variable standardPadding was used in 3 places where as it's value is used in countless. It seems better to remove the variable since it's not consistently used and would only confuse anyone looking at the codebase in the future.
Since the value was changed in transition.css, the affected components were given the proper padding in their respective transition css. This applied to table.scss and collapsible.scss